### PR TITLE
Fix mech caravan destruction and update docs

### DIFF
--- a/1.5/Source/CaravanMechanoidPatch.cs
+++ b/1.5/Source/CaravanMechanoidPatch.cs
@@ -535,4 +535,27 @@ namespace CrystalMechanoids
             return codes.AsEnumerable();
         }
     }
+    // Patch Caravan.Notify_PawnKilled so caravans with mechanoids aren't destroyed when the last human dies
+    [HarmonyPatchCategory("BaseGame")]
+    [HarmonyPatch(typeof(Caravan), nameof(Caravan.Notify_PawnKilled))]
+    public static class Caravan_Notify_PawnKilled_Patch {
+        public static bool Prefix(Caravan __instance, Pawn pawn) {
+            if (__instance == null || pawn == null) return true;
+
+            if (PatchHelpers.HasMechanoids(__instance.pawns)) {
+                bool hasColonist = false;
+                bool hasMech = false;
+                foreach (Pawn p in __instance.pawns) {
+                    if (p == pawn) continue;
+                    if (p?.RaceProps?.IsMechanoid == true) hasMech = true;
+                    if (p?.IsColonist == true) { hasColonist = true; break; }
+                }
+                if (!hasColonist && hasMech) {
+                    __instance.RemovePawn(pawn);
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
 }

--- a/Languages/English/Keyed/CrystalMechanoids.xml
+++ b/Languages/English/Keyed/CrystalMechanoids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
-
+    <CrystalMechanoids_ModName>CrystalMechanoids</CrystalMechanoids_ModName>
+    <CrystalMechanoids_Description>Allows creation of mechanoid-only caravans.</CrystalMechanoids_Description>
 </LanguageData>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-CrystalMechanoids
+# CrystalMechanoids
+
+CrystalMechanoids allows RimWorld players to form and operate caravans made entirely of mechanoids. The mod patches many vanilla checks so mech-only caravans work properly and remain functional even when all human colonists die.
+
+## Building
+
+Use the included Visual Studio solution to compile the mod:
+
+```
+dotnet build 1.5/Source/CrystalMechanoids.sln -c Release
+```
+
+The compiled assembly will be placed under `1.5/Assemblies`.
+
+## Usage
+
+Enable the mod in RimWorld and create or reform caravans with your mechanoids. If the last human dies, the caravan will continue to exist with the remaining mechs.


### PR DESCRIPTION
## Summary
- prevent caravans with surviving mechanoids from being destroyed when the last human dies
- document build instructions and usage
- add initial English translation strings

## Testing
- `dotnet build 1.5/Source/CrystalMechanoids.sln -c Release` *(fails: missing RimWorld references)*

------
https://chatgpt.com/codex/tasks/task_e_6843815a37d88320b6b24c506f69145e